### PR TITLE
fix: DockerイメージのデフォルトコマンドをENTRYPOINTに修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ EOF
 
 USER "1000:1000"
 
-CMD [ "python", "-m", "xivbookmarkdl" ]
+ENTRYPOINT [ "python", "-m", "xivbookmarkdl" ]


### PR DESCRIPTION
間違えてENTRYPOINTをCMDに変更してしまっていたので修正します。